### PR TITLE
Fix typo in comment and Markdown link

### DIFF
--- a/zapache/README.md
+++ b/zapache/README.md
@@ -98,7 +98,7 @@ If everything is fine, reset debug and send_to_zabbix to their original values a
 
 ### Zabbix Template
 
-Import the [Zabbix template](/zapache/zabbix template/zbx_template_apache.xml), this template includes all default values and is ready to use :
+Import the [Zabbix template](</zapache/zabbix template/zbx_template_apache.xml>), this template includes all default values and is ready to use :
 
 * HTTP total requests per second
 

--- a/zapache/zapache.py
+++ b/zapache/zapache.py
@@ -32,7 +32,7 @@ logtail_file = "/tmp/zapache-logtail.data"			# Logtail output (delta file)
 
 # Zapache
 debug = 0 											# Debug : 0 = Off
-send_to_zabbix = 1 							# Send data to zabbix ? > 0 = Yes / 0 = No
+send_to_zabbix = 1 							# Send data to zabbix ? > 1 = Yes / 0 = No
 my_resp_code = ("400", "401", "402", "403", "404", "405", "406", "408", "409", "410", "411", "412", "413", "414", "417", "500", "501", "502", "503", "504")				# Wanted status code.
 my_req_type = ("GET", "POST")																																			# Wanted request type
 
@@ -127,7 +127,7 @@ def logtail_that_file():
 
   	TAILFILE.close()
 
-# Zend values to zabbix via zabbix_sender
+# Send values to zabbix via zabbix_sender
 def zabbix_send(metric, value):
 	key = zabbix_key + "[" + metric + "]"					# Generate zabbix key => zabbix_key[metric]
 	if debug == 1:


### PR DESCRIPTION
Fix typo in comments:
Zend -> Send
1 -> Yes

and Markdown link to the xml template